### PR TITLE
Chrome options V2

### DIFF
--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -239,7 +239,7 @@ var arr = [],
 
 /*Creating a new tab if notification is clicked*/
 chrome.alarms.create("routine", {
-    delayInMinutes: .1
+    delayInMinutes: 1
 }), chrome.notifications.onClicked.addListener(function() {
 	chrome.windows.getCurrent(function(currentWindow) {
 		if (currentWindow != null) {

--- a/chromeOptions.css
+++ b/chromeOptions.css
@@ -1,0 +1,12 @@
+#settingsDiv{
+      visibility: visible;
+      position: relative;
+      left: auto;
+      margin-left: auto;
+      margin-top: auto;
+}
+
+body, #titlesList{
+      margin: 0;
+      padding: 0;
+}

--- a/chromeOptions.js
+++ b/chromeOptions.js
@@ -1,4 +1,168 @@
-window.onload = function() {
-	//Remove the cancel button
-	document.getElementById("btnSetCancel").remove();
-}
+var newVersionLaunched = false;
+var settingsInfiniteScrolling = false;
+var settingsShowPoints = false;
+var settingsShowButtons = false;
+var settingsLoadFive = false;
+var settingsHideDlc = false;
+var settingsRepeatIfOnPage = false;
+var settingsRepeatHours = 2;
+var settingsNightTheme = false;
+var settingsLevelPriority = false;
+var settingsBackgroundAJ = false;
+var settingsLevelPriorityBG = false;
+var settingsOddsPriorityBG = false;
+var settingsHideEntered = false;
+var settingsPagestoload = 3;
+var settingsPagestoloadBG = 2;
+var settingsPageForBG = "wishlist";
+var settingsRepeatHoursBG = 2;
+var settingsHideGroups = false;
+var settingsIgnoreGroups = false;
+var settingsIgnoreGroupsBG = false;
+var settingsIgnorePinnedBG = false;
+var settingsPlayAudio = true;
+var settingsDelayBG = 10;
+var settingsMinLevelBG = 0;
+var settingsIgnorePinned = false;
+var settingsShowChance = true;
+
+$(document).ready(function() {
+
+	$("#btnSetCancel").remove();
+
+	chrome.storage.sync.get({
+		HideGroups: 'false',
+		IgnoreGroups: 'false',
+		IgnorePinned: 'true',
+		IgnoreGroupsBG: 'false',
+		IgnorePinnedBG: 'false',
+		HideEntered: 'false',
+		PageForBG: 'wishlist',
+		RepeatHoursBG: '2',
+		Pagestoload: '3',
+		PagestoloadBG: '2',
+		BackgroundAJ: 'true',
+		LevelPriorityBG: 'true',
+		OddsPriorityBG: 'false',
+		lastLaunchedVersion: '20160226',
+		infiniteScrolling: 'true',
+		showPoints: 'true',
+		showButtons: 'true',
+		loadFive: 'false',
+		hideDlc: 'false',
+		repeatIfOnPage: 'false',
+		repeatHours: '2',
+		nightTheme: 'false',
+		levelPriority: 'false',
+		PlayAudio: 'true',
+		DelayBG: '10',
+		MinLevelBG: '0',
+		ShowChance: 'true'
+		}, function(data) {
+			settingsHideGroups = (data['HideGroups'] == 'true');
+			settingsIgnoreGroups = (data['IgnoreGroups'] == 'true');
+			settingsIgnorePinned = (data['IgnorePinned'] == 'true');
+			settingsIgnoreGroupsBG = (data['IgnoreGroupsBG'] == 'true');
+			settingsIgnorePinnedBG = (data['IgnorePinnedBG'] == 'true');
+			settingsHideEntered = (data['HideEntered'] == 'true');
+			settingsPageForBG = data['PageForBG'];
+			settingsRepeatHoursBG = parseInt(data['RepeatHoursBG'], 10);
+			settingsPagestoload = parseInt(data['Pagestoload'], 10);
+			settingsPagestoloadBG = parseInt(data['PagestoloadBG'], 10);
+			settingsDelayBG = parseInt(data['DelayBG'], 10);
+			settingsMinLevelBG = parseInt(data['MinLevelBG'], 10);
+			settingsBackgroundAJ = (data['BackgroundAJ'] == 'true');
+			settingsLevelPriorityBG = (data['LevelPriorityBG'] == 'true');
+			settingsOddsPriorityBG = (data['OddsPriorityBG'] == 'true');
+			if (!(parseInt(data['lastLaunchedVersion'], 10) < 20160226)){
+				newVersionLaunched = true;
+				chrome.storage.sync.set({'lastLaunchedVersion': '20160226'});
+			}
+			settingsInfiniteScrolling = (data['infiniteScrolling'] == 'true');
+			settingsShowPoints = (data['showPoints'] == 'true');
+			settingsShowButtons = (data['showButtons'] == 'true');
+			settingsLoadFive = (data['loadFive'] == 'true');
+			settingsHideDlc = (data['hideDlc'] == 'true');
+			settingsRepeatIfOnPage = (data['repeatIfOnPage'] == 'true');
+			settingsRepeatHours = parseInt(data['repeatHours'], 10);
+			settingsNightTheme = (data['nightTheme'] == 'true');
+			settingsLevelPriority = (data['levelPriority'] == 'true');
+			settingsPlayAudio = (data['PlayAudio'] == 'true');
+			settingsShowChance = (data['ShowChance'] == 'true');
+
+			fillSettingsDiv();
+		}
+	);
+});
+
+function fillSettingsDiv(){
+
+	if (settingsInfiniteScrolling){$('#chkInfiniteScroll').prop('checked', true)};
+	if (settingsShowPoints){$('#chkShowPoints').prop('checked', true)};
+	if (settingsShowButtons){$('#chkShowButtons').prop('checked', true)};
+	if (settingsLoadFive){$('#chkLoadFive').prop('checked', true)};
+	if (settingsHideDlc){$('#chkHideDlc').prop('checked', true)};
+	if (settingsNightTheme){$('#chkNightTheme').prop('checked', true)};
+	if (settingsLevelPriority){$('#chkLevelPriority').prop('checked', true)};
+	if (settingsRepeatIfOnPage){$('#chkRepeatIfOnPage').prop('checked', true)};
+	if (settingsHideEntered){$('#chkHideEntered').prop('checked', true)};
+	if (settingsHideGroups){$('#chkHideGroups').prop('checked', true)};
+	if (settingsIgnoreGroups){$('#chkIgnoreGroups').prop('checked', true)};
+	if (settingsIgnorePinned){$('#chkIgnorePinned').prop('checked', true)};
+	if (settingsIgnoreGroupsBG){$('#chkIgnoreGroupsBG').prop('checked', true)};
+	if (settingsIgnorePinnedBG){$('#chkIgnorePinnedBG').prop('checked', true)};
+	if (settingsBackgroundAJ){$('#chkEnableBG').prop('checked', true)};
+	if (settingsLevelPriorityBG){$('#chkLevelPriorityBG').prop('checked', true)};
+	if (settingsOddsPriorityBG){$('#chkOddsPriorityBG').prop('checked', true)};
+	if (settingsPlayAudio){$('#chkPlayAudio').prop('checked', true)};
+	if (settingsShowChance){$('#chkShowChance').prop('checked', true)};
+	$('#hoursField').val(settingsRepeatHours);
+	$('#pagestoload').val(settingsPagestoload);
+	$('#pagestoloadBG').val(settingsPagestoloadBG);
+	if (settingsRepeatHoursBG == 0) { $('#hoursFieldBG').val("0.5") } else { $('#hoursFieldBG').val(settingsRepeatHoursBG) }
+	$('#pageforBG').val(settingsPageForBG);
+	$('#delayBG').val(settingsDelayBG);
+	$('#minLevelBG').val(settingsMinLevelBG);
+
+	
+	$('#btnSetSave').click(function(){
+		chrome.storage.sync.set({
+			infiniteScrolling: $('#chkInfiniteScroll').is(':checked').toString(),
+			showPoints: $('#chkShowPoints').is(':checked').toString(),
+			showButtons: $('#chkShowButtons').is(':checked').toString(),
+			loadFive: $('#chkLoadFive').is(':checked').toString(),
+			hideDlc: $('#chkHideDlc').is(':checked').toString(),
+			repeatIfOnPage: $('#chkRepeatIfOnPage').is(':checked').toString(),
+			nightTheme: $('#chkNightTheme').is(':checked').toString(),
+			levelPriority: $('#chkLevelPriority').is(':checked').toString(),
+			LevelPriorityBG: $('#chkLevelPriorityBG').is(':checked').toString(),
+			OddsPriorityBG: $('#chkOddsPriorityBG').is(':checked').toString(),
+			BackgroundAJ: $('#chkEnableBG').is(':checked').toString(),
+			HideEntered: $('#chkHideEntered').is(':checked').toString(),
+			IgnoreGroups: $('#chkIgnoreGroups').is(':checked').toString(),
+			IgnorePinned: $('#chkIgnorePinned').is(':checked').toString(),
+			IgnoreGroupsBG: $('#chkIgnoreGroupsBG').is(':checked').toString(),
+			IgnorePinnedBG: $('#chkIgnorePinnedBG').is(':checked').toString(),
+			HideGroups: $('#chkHideGroups').is(':checked').toString(),
+			PlayAudio: $('#chkPlayAudio').is(':checked').toString(),
+			repeatHours: $('#hoursField').val(),
+			RepeatHoursBG: parseInt($('#hoursFieldBG').val()), //parseInt to save 0.5 as 0
+			Pagestoload: $('#pagestoload').val(),
+			PagestoloadBG: $('#pagestoloadBG').val(),
+			PageForBG: $('#pageforBG').val(),
+			DelayBG: $('#delayBG').val(),
+			MinLevelBG: $('#minLevelBG').val(),
+			ShowChance: $('#chkShowChance').is(':checked').toString()
+		}, function(){
+			alert("Settings Saved!")
+		});		
+	});
+
+	//to show 0.5 when value goes below 1 in hoursFieldBG field 
+	$("#hoursFieldBG").on('input', function() {
+		if (this.value == 0) this.value = 0.5;
+		else if (this.value % 1 != 0 & this.value > 1) {
+			this.value = parseInt(this.value);
+		}
+	});
+};

--- a/chromeOptions.js
+++ b/chromeOptions.js
@@ -1,0 +1,4 @@
+window.onload = function() {
+	//Remove the cancel button
+	document.getElementById("btnSetCancel").remove();
+}

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
        "settings.html",
        "night.css" 
     ],
-   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm/FQjecKEYQPsR+QswcsO4zN8TGAhkJVRR3fVSk28RSIXyDq8RXBHvGVJZnubt6YCX5N3ub/YWAsP+IrOnBkJ5UiEEZ0ldcRXPqmtKqX6XPYwKO4D2U2OKgVq9lLqOo3zP4P1r8dnQWz0c6DAbLpvN5IMA9/J8HLTKzUOOfPfHtJMiWvxGzrPpm17ctmIWp3yN82BZtkoyOxuOSiKqxfK+piQRpXGecQsl8SfIcI6WKx7zxbuFanM3D9SkMUtl5wCatDixcbw9Jnk4df2/tBCjYIBagKbLo4+eN+ARf9G4pUjnA8PV+fc9vAk0v67qVSOd+e4ZeSKtDJMb/76uSDPwIDAQAB",
+   
     "options_ui": {
       "page": "settings.html",
       "chrome_style": true

--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,10 @@
    "web_accessible_resources": [ 
        "settings.html",
        "night.css" 
-    ]
+    ],
+   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm/FQjecKEYQPsR+QswcsO4zN8TGAhkJVRR3fVSk28RSIXyDq8RXBHvGVJZnubt6YCX5N3ub/YWAsP+IrOnBkJ5UiEEZ0ldcRXPqmtKqX6XPYwKO4D2U2OKgVq9lLqOo3zP4P1r8dnQWz0c6DAbLpvN5IMA9/J8HLTKzUOOfPfHtJMiWvxGzrPpm17ctmIWp3yN82BZtkoyOxuOSiKqxfK+piQRpXGecQsl8SfIcI6WKx7zxbuFanM3D9SkMUtl5wCatDixcbw9Jnk4df2/tBCjYIBagKbLo4+eN+ARf9G4pUjnA8PV+fc9vAk0v67qVSOd+e4ZeSKtDJMb/76uSDPwIDAQAB",
+    "options_ui": {
+      "page": "settings.html",
+      "chrome_style": true
+   }
 }

--- a/settings.html
+++ b/settings.html
@@ -1,139 +1,149 @@
-<div id="settingsDiv">
-    <ul id="titlesList">
-        <li class="titleListItem">General settings</li>
-        <ul>
-            <li>
-                <label> 
-                        <input id="chkInfiniteScroll" type="checkbox"/>Enable Infinite Scrolling (also hides everything below giveaways)
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkShowPoints" type="checkbox"/>Show points and level in top-left corner if scrolled down
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkShowButtons" type="checkbox"/>Show buttons to join/leave and warnings besides each giveaway
-                    </label>
-            </li>
-            <li>
-                <label>
-                        <input id="chkShowChance" type="checkbox" />Show approximate odds of winning
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkLoadFive" type="checkbox"/>Load 
-                        <input type="number" size="2" id="pagestoload" min="1" max="5" value="3"> pages before trying to Auto-join (1-5)
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkHideDlc" type="checkbox"/>Hide all DLC giveaways
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkRepeatIfOnPage" type="checkbox"/>AutoJoin every 
-                        <input type="number" size="2" id="hoursField" min="1" max="24" value="2"> hours if page is opened (1-24)
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkNightTheme" type="checkbox"/>Enable Night theme
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkHideEntered" type="checkbox"/>Hide joined giveaways
-                    </label>
-            </li>
-            <li>
-                <label> 
-                        <input id="chkIgnoreGroups" type="checkbox"/>Ignore group giveaways for AutoJoin
-                    </label> &nbsp;&nbsp;
-                <label> 
-                        <input id="chkHideGroups" type="checkbox"/>Completely hide them
-                    </label>
-            </li>
-            <li>
-                <label>
-                        <input id="chkIgnorePinned" type="checkbox">Ignore featured giveaways for AutoJoin
-                    </label>
-            </li>
-        </ul>
-        <br />
-        <li class="titleListItem">AutoJoin in background (even when steamgifts.com in not opened)</li>
-        <ul>
-            <li>
-                <label>
-                        <input id="chkEnableBG" type="checkbox"/>Enable AutoJoin in background on 
-                        <select style="width: 150px;" id="pageforBG"> 
-                            <option value="all">        Main page (All) </option>
-                            <option value="wishlist">   Wishlist        </option>
-                            <option value="group">      Group           </option>
-                            <option value="new">        New             </option>
-                            <option value="recommended">Recommended     </option>
-                        </select>
-                    </label>
-            </li>
-            <li>
-                Priority:&nbsp;
-                <label><input id="chkNoPriorityBG" name="BGpriority" type="radio" checked="checked"/>No priority</label>&nbsp;&nbsp;
-                <label><input id="chkLevelPriorityBG" name="BGpriority" type="radio" />Higher level giveaways</label>&nbsp;&nbsp;
-                <label><input id="chkOddsPriorityBG" name="BGpriority" type="radio" />Higher odds of winning</label>
-            </li>
-            <li>
-                <label>
-                        <input id="chkIgnoreGroupsBG" type="checkbox"/>Ignore groups giveaways for Main page (All)
-                    </label>
-            </li>
-            <li>
-                <label>
-                        <input id="chkIgnorePinnedBG" type="checkbox"/>Ignore featured giveaways (All)
-                    </label>
-            </li>
-            <li>
-                <label>
-                        <input id="chkPlayAudio" type="checkbox"/>Play sound when won
-                    </label>
-            </li>
-            <li>
-                <label>Try to AutoJoin in background every 
-                        <input type="number" size="2" id="hoursFieldBG" min="1" max="24" value="2"> hours (1-24)
-                    </label>
-            </li>
-            <li>
-                <label>Load 
-                        <input type="number" size="2" id="pagestoloadBG" min="1" max="3" value="2"> pages before trying to join giveaways (1-3)
-                    </label>
-            </li>
-            <li>
-                <label>Delay between requests: 
-                        <input type="number" size="2" id="delayBG" min="5" max="60" value="10"> seconds
-                    </label>
-            </li>
-            <li>
-                <label>Minimum giveaway level to enter: 
-                        <input type="number" size="2" id="minLevelBG" min="0" max="10" value="0"> (set it to 0 to enter all giveaways)
-                    </label>
-            </li>
-        </ul>
-    </ul>
-    <div id="rateSteamContainer">
-        <ul>
-            <li>
-                <a target="_blank" href="https://chrome.google.com/webstore/detail/autojoin-for-steamgifts/bchhlccjhoedhhegglilngpbnldfcidc">Rate this extension in Chrome Web Store
-                </a>
-            </li>
-            <li>
-                <a target="_blank" href="http://steamcommunity.com/groups/autojoin">Join Steam group</a>
-            </li>
-        </ul>
-    </div>
-    <div id="SaveCancelContainer">
-        <button id="btnSetSave">Save</button> &nbsp;&nbsp; <button id="btnSetCancel" class="settingsCancel">Cancel</button>
-    </div>
-</div>
-<div id="settingsShade" class="settingsCancel" \>
+<!doctype html>
+<html>
+    <head>
+        <link rel="alternate stylesheet" href="general.css" title="chromeOptions" />
+        <link rel="stylesheet" href="chromeOptions.css" title="chromeOptions" />
+        <script type="text/javascript" src="chromeOptions.js"></script>
+    </head>
+    <body>
+        <div id="settingsDiv">
+            <ul id="titlesList">
+                <li class="titleListItem">General settings</li>
+                <ul>
+                    <li>
+                        <label> 
+                                <input id="chkInfiniteScroll" type="checkbox"/>Enable Infinite Scrolling (also hides everything below giveaways)
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkShowPoints" type="checkbox"/>Show points and level in top-left corner if scrolled down
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkShowButtons" type="checkbox"/>Show buttons to join/leave and warnings besides each giveaway
+                            </label>
+                    </li>
+                    <li>
+                        <label>
+                                <input id="chkShowChance" type="checkbox" />Show approximate odds of winning
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkLoadFive" type="checkbox"/>Load 
+                                <input type="number" size="2" id="pagestoload" min="1" max="5" value="3"> pages before trying to Auto-join (1-5)
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkHideDlc" type="checkbox"/>Hide all DLC giveaways
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkRepeatIfOnPage" type="checkbox"/>AutoJoin every 
+                                <input type="number" size="2" id="hoursField" min="1" max="24" value="2"> hours if page is opened (1-24)
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkNightTheme" type="checkbox"/>Enable Night theme
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkHideEntered" type="checkbox"/>Hide joined giveaways
+                            </label>
+                    </li>
+                    <li>
+                        <label> 
+                                <input id="chkIgnoreGroups" type="checkbox"/>Ignore group giveaways for AutoJoin
+                            </label> &nbsp;&nbsp;
+                        <label> 
+                                <input id="chkHideGroups" type="checkbox"/>Completely hide them
+                            </label>
+                    </li>
+                    <li>
+                        <label>
+                                <input id="chkIgnorePinned" type="checkbox">Ignore featured giveaways for AutoJoin
+                            </label>
+                    </li>
+                </ul>
+                <br />
+                <li class="titleListItem">AutoJoin in background (even when steamgifts.com in not opened)</li>
+                <ul>
+                    <li>
+                        <label>
+                                <input id="chkEnableBG" type="checkbox"/>Enable AutoJoin in background on 
+                                <select style="width: 150px;" id="pageforBG"> 
+                                    <option value="all">        Main page (All) </option>
+                                    <option value="wishlist">   Wishlist        </option>
+                                    <option value="group">      Group           </option>
+                                    <option value="new">        New             </option>
+                                    <option value="recommended">Recommended     </option>
+                                </select>
+                            </label>
+                    </li>
+                    <li>
+                        Priority:&nbsp;
+                        <label><input id="chkNoPriorityBG" name="BGpriority" type="radio" checked="checked"/>No priority</label>&nbsp;&nbsp;
+                        <label><input id="chkLevelPriorityBG" name="BGpriority" type="radio" />Higher level giveaways</label>&nbsp;&nbsp;
+                        <label><input id="chkOddsPriorityBG" name="BGpriority" type="radio" />Higher odds of winning</label>
+                    </li>
+                    <li>
+                        <label>
+                                <input id="chkIgnoreGroupsBG" type="checkbox"/>Ignore groups giveaways for Main page (All)
+                            </label>
+                    </li>
+                    <li>
+                        <label>
+                                <input id="chkIgnorePinnedBG" type="checkbox"/>Ignore featured giveaways (All)
+                            </label>
+                    </li>
+                    <li>
+                        <label>
+                                <input id="chkPlayAudio" type="checkbox"/>Play sound when won
+                            </label>
+                    </li>
+                    <li>
+                        <label>Try to AutoJoin in background every 
+                                <input type="number" size="2" id="hoursFieldBG" min="1" max="24" value="2"> hours (1-24)
+                            </label>
+                    </li>
+                    <li>
+                        <label>Load 
+                                <input type="number" size="2" id="pagestoloadBG" min="1" max="3" value="2"> pages before trying to join giveaways (1-3)
+                            </label>
+                    </li>
+                    <li>
+                        <label>Delay between requests: 
+                                <input type="number" size="2" id="delayBG" min="5" max="60" value="10"> seconds
+                            </label>
+                    </li>
+                    <li>
+                        <label>Minimum giveaway level to enter: 
+                                <input type="number" size="2" id="minLevelBG" min="0" max="10" value="0"> (set it to 0 to enter all giveaways)
+                            </label>
+                    </li>
+                </ul>
+            </ul>
+            <div id="rateSteamContainer">
+                <ul>
+                    <li>
+                        <a target="_blank" href="https://chrome.google.com/webstore/detail/autojoin-for-steamgifts/bchhlccjhoedhhegglilngpbnldfcidc">Rate this extension in Chrome Web Store
+                        </a>
+                    </li>
+                    <li>
+                        <a target="_blank" href="http://steamcommunity.com/groups/autojoin">Join Steam group</a>
+                    </li>
+                </ul>
+            </div>
+            <div id="SaveCancelContainer">
+                <button id="btnSetSave">Save</button> &nbsp;&nbsp; <button id="btnSetCancel" class="settingsCancel">Cancel</button>
+            </div>
+        </div>
+        <div id="settingsShade" class="settingsCancel" \></div>
+    </body>
+</html>

--- a/settings.html
+++ b/settings.html
@@ -3,6 +3,8 @@
     <head>
         <link rel="alternate stylesheet" href="general.css" title="chromeOptions" />
         <link rel="stylesheet" href="chromeOptions.css" title="chromeOptions" />
+
+        <script type="text/javascript" src="jquery.min.js"></script>
         <script type="text/javascript" src="chromeOptions.js"></script>
     </head>
     <body>
@@ -144,6 +146,6 @@
                 <button id="btnSetSave">Save</button> &nbsp;&nbsp; <button id="btnSetCancel" class="settingsCancel">Cancel</button>
             </div>
         </div>
-        <div id="settingsShade" class="settingsCancel" \></div>
+        <div id="settingsShade" class="settingsCancel"></div>
     </body>
 </html>


### PR DESCRIPTION
I completed the options V2 thing, it doesn't look very good, it's very basic, and the code isn't the finest, but it's functionnal. I'm running out of time this weekend, so it's up to you to modify what you want on the chromeOptions branch, if you want to add/modify features.

Here is what it looks like for now:
![image](https://cloud.githubusercontent.com/assets/5382590/22185839/3b9b4406-e0ed-11e6-8596-d2f489076f9a.png)

Please don't merge now, as the "append to document" part is not finished, or merge into a development branch.
I can't really continue working on the extension, because I just got a 24 hours ban for suspicious traffic :/ (I guess I refreshed too much, and the alarm triggered too many times as I reload the extension)
Here are my attempts at trying to get settings.html's body with jquery:

`$.get(chrome.extension.getURL('/settings.html'), function(settingsDiv){

		var settdiv = $.parseHTML(settingsDiv);

		console.log($(settingsDiv).filter("#settingsDiv").html());

		console.log($(settingsDiv).filter($("body")).html());

		settdiv = $(settdiv).find("#settingsDiv");`

If I had more time, I guess I could move the fillSettingsDiv function to another file or something that could be used both by chrome options and on page options.
To sum up:
Working Options V2 - Done
Still works with on page options - Todo

Good luck