### PR TITLE
Option to keep a # of minimum points for background autojoin

### DIFF
--- a/autoentry.js
+++ b/autoentry.js
@@ -83,6 +83,7 @@ function tempStart() { // this is temporary
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
+		MinPoints: 0,
 		ShowChance: true
 		}, function(data) {
 			settings = data;

--- a/autoentry.js
+++ b/autoentry.js
@@ -83,7 +83,7 @@ function tempStart() { // this is temporary
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
-		MinPoints: 0,
+		PointsToPreserve: 0,
 		ShowChance: true
 		}, function(data) {
 			settings = data;

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -94,7 +94,7 @@ function pagesloaded() {
 				var entCnt = 0;
 				var pointDiff = myPoints - settings.MinPoints;
 				$.each(arr, function(e) {
-					if(totalCost < pointDiff || totalCost == 0){
+					if((totalCost < pointDiff || totalCost == 0) && arr[e].level > settings.MinLevelBG && arr[e].cost > settings.MinCost){
 						totalCost += arr[e].cost;
 						entCnt++;
 					}else{
@@ -102,16 +102,10 @@ function pagesloaded() {
 					}
 				});
 				arr = arr.splice(0, entCnt);
+				console.log(myPoints);
 				
 				var timeouts = [];
 				$.each(arr, function(e) {
-					if (arr[e].level < settings.MinLevelBG) { // this may be unnecessary since level_min search parameter https://www.steamgifts.com/discussion/5WsxS/new-search-parameters
-						return true;
-					}
-					if (arr[e].cost < settings.MinCost){
-						return true;
-					}
-					
 					timeouts.push(setTimeout(function(){
 						console.log(arr[e]), $.post("https://www.steamgifts.com/ajax.php", {
 							xsrf_token: token,

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -97,6 +97,8 @@ function pagesloaded() {
 					if(totalCost < pointDiff || totalCost == 0){
 						totalCost += arr[e].cost;
 						entCnt++;
+					}else{
+						return false;
 					}
 				});
 				arr = arr.splice(0, entCnt);

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -100,7 +100,7 @@ var currPoints=0;
 						totalCost += arr[e].cost;
 						entCnt++;
 						
-						if(entCnt != 1 && totalCost < pointDiff){
+						if(entCnt != 1 && totalCost > pointDiff){
 							entCnt++; 
 							/*This is to go under the preserve limit for the case where
 							the entered giveaway is the last one and we are still above the preserve limit

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -105,7 +105,7 @@ function pagesloaded() {
 							code: arr[e].code
 						}, function(response){
 							var json_response = jQuery.parseJSON(response);
-							if (json_response.points < settings.PointsToPreserve) {
+							if (json_response.points < settings.PointsToPreserve || json_response.msg == "Not Enough Points") {
 								for (var i = 0; i < timeouts.length; i++) {
 									clearTimeout(timeouts[i]);
 								}

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -84,25 +84,34 @@ function pagesloaded() {
 	} else if (settings.OddsPriorityBG) {
 		arr.sort(compareOdds);
 	}
-	var myPoints=0;
+var currPoints=0;
 	link = "https://www.steamgifts.com/";
 	$.get(link, function(data) {
-		myPoints = parseInt($(data).find('a[href="/account"]').find("span.nav__points").text(), 10);
+		currPoints = parseInt($(data).find('a[href="/account"]').find("span.nav__points").text(), 10);
 		}).done(function(){
-			if(myPoints >= settings.MinPoints){
+			if(currPoints >= settings.PointsToPreserve){
 				var totalCost = 0;
 				var entCnt = 0;
-				var pointDiff = myPoints - settings.MinPoints;
+				var pointDiff = currPoints - settings.PointsToPreserve;
 				$.each(arr, function(e) {
-					if((totalCost < pointDiff || totalCost == 0) && arr[e].level > settings.MinLevelBG && arr[e].cost > settings.MinCost){
+					if((totalCost < pointDiff || totalCost == 0) 
+						&& arr[e].level > settings.MinLevelBG 
+						&& arr[e].cost > settings.MinCost){
 						totalCost += arr[e].cost;
 						entCnt++;
+						
+						if(entCnt != 1 && totalCost < pointDiff){
+							entCnt++; 
+							/*This is to go under the preserve limit for the case where
+							the entered giveaway is the last one and we are still above the preserve limit
+							but the last giveaway puts your points under the limit*/
+						}
 					}else{
 						return false;
 					}
 				});
 				arr = arr.splice(0, entCnt);
-				console.log(myPoints);
+				console.log('Current Points: ' + currPoints);
 				
 				var timeouts = [];
 				$.each(arr, function(e) {
@@ -188,7 +197,7 @@ function loadsettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
-		MinPoints: 0,
+		PointsToPreserve: 0,
 		PagesToLoadBG: 3,
 		BackgroundAJ: true,
 		LevelPriorityBG: true,

--- a/settings.html
+++ b/settings.html
@@ -137,7 +137,7 @@
                         </li>
 						<li>
                             <label>Keep a minimum of
-                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
+                                    <input type="number" size="3" id="PointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>
                     </ul>

--- a/settings.html
+++ b/settings.html
@@ -135,6 +135,11 @@
                                     <input type="number" size="3" id="minCost" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
                                 </label>
                         </li>
+						<li>
+                            <label>Keep a minimum of
+                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (can decrease efficiency depending on autojoin check hours and the minimum number)
+                                </label>
+                        </li>
                     </ul>
                 </ul>
                 <div id="linksContainer">

--- a/settings.html
+++ b/settings.html
@@ -137,7 +137,7 @@
                         </li>
 						<li>
                             <label>Keep a minimum of
-                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (can decrease efficiency depending on autojoin check hours and the minimum number)
+                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>
                     </ul>

--- a/settings.html
+++ b/settings.html
@@ -136,7 +136,7 @@
                                 </label>
                         </li>
 						<li>
-                            <label>Keep a minimum of
+                            <label>Preserve
                                     <input type="number" size="3" id="pointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>

--- a/settings.html
+++ b/settings.html
@@ -137,7 +137,7 @@
                         </li>
 						<li>
                             <label>Keep a minimum of
-                                    <input type="number" size="3" id="PointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
+                                    <input type="number" size="3" id="pointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>
                     </ul>

--- a/settings.js
+++ b/settings.js
@@ -27,6 +27,7 @@ function loadSettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
+		MinPoints: 0,
 		ShowChance: true
 		}, function(settings) {
 			fillSettingsDiv(settings);
@@ -61,6 +62,7 @@ function fillSettingsDiv(settings){
 	document.getElementById("delayBG").value = settings.DelayBG;
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
+	document.getElementById("minPoints").value = settings.MinPoints;
 	if (settings.RepeatHoursBG == 0) { 
 		document.getElementById("hoursFieldBG").value = "0.5"; 
 	} else { 
@@ -100,6 +102,7 @@ function settingsAttachEventListeners(){
 			DelayBG: parseInt(document.getElementById("delayBG").value, 10),
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
+			MinPoints: parseInt(document.getElementById("minPoints").value, 10),
 			ShowChance: document.getElementById("chkShowChance").checked
 		}, function(){
 			if (location.protocol == "chrome-extension:"){

--- a/settings.js
+++ b/settings.js
@@ -27,7 +27,7 @@ function loadSettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
-		MinPoints: 0,
+		PointsToPreserve: 0,
 		ShowChance: true
 		}, function(settings) {
 			fillSettingsDiv(settings);
@@ -62,7 +62,7 @@ function fillSettingsDiv(settings){
 	document.getElementById("delayBG").value = settings.DelayBG;
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
-	document.getElementById("minPoints").value = settings.MinPoints;
+	document.getElementById("pointsToPreserve").value = settings.PointsToPreserve;
 	if (settings.RepeatHoursBG == 0) { 
 		document.getElementById("hoursFieldBG").value = "0.5"; 
 	} else { 
@@ -102,7 +102,7 @@ function settingsAttachEventListeners(){
 			DelayBG: parseInt(document.getElementById("delayBG").value, 10),
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
-			MinPoints: parseInt(document.getElementById("minPoints").value, 10),
+			PointsToPreserve: parseInt(document.getElementById("pointsToPreserve").value, 10),
 			ShowChance: document.getElementById("chkShowChance").checked
 		}, function(){
 			if (location.protocol == "chrome-extension:"){


### PR DESCRIPTION
I wanted this option so i started working on this yesterday. With my limited Java and almost non-existent JS knowledge, searching around the net how i can do what i want to do, this was the result.
Most likely this is not the right way to do this but it seems to work so feel free to merge.

Basically this keeps the number of points specified in options menu and if enabled spends the rest for autojoin in background. If a giveaway exceeds the amount of points you've allowed for autojoin in the background, the script will still join that giveaway. For example;
You have 286 points, in the options menu you've set 250P to keep but a 100P giveaway showed up and you only allowed 50P for autojoin (300P-250P), script will join that giveaway leaving the account with 186P.