### PR TITLE
Option to prioritize wishlist on (All) for background autojoin and an option to ignore preserve points on said option

### DIFF
--- a/autoentry.js
+++ b/autoentry.js
@@ -83,6 +83,7 @@ function tempStart() { // this is temporary
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
+		MinPoints: 0,
 		ShowChance: true
 		}, function(data) {
 			settings = data;

--- a/autoentry.js
+++ b/autoentry.js
@@ -83,7 +83,7 @@ function tempStart() { // this is temporary
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
-		MinPoints: 0,
+		PointsToPreserve: 0,
 		ShowChance: true
 		}, function(data) {
 			settings = data;

--- a/autoentry.js
+++ b/autoentry.js
@@ -44,7 +44,6 @@ $(document).ready(function() {
 				DelayBG: 10,
 				MinLevelBG: 0,
 				MinCost: 0,
-				PointsToPreserve: 0,
 				ShowChance: true
 			}, function(data) {
 				settings = data;
@@ -53,46 +52,6 @@ $(document).ready(function() {
 		}
 	});
 });
-<<<<<<< HEAD
-function tempStart() { // this is temporary
-	chrome.storage.sync.get({
-		HideGroups: false,
-		IgnoreGroups: false,
-		IgnorePinned: true,
-		IgnoreGroupsBG: false,
-		IgnorePinnedBG: false,
-		HideEntered: false,
-		PageForBG: 'wishlist',
-		RepeatHoursBG: 2,
-		PagesToLoad: 3,
-		PagesToLoadBG: 2,
-		BackgroundAJ: true,
-		LevelPriorityBG: true,
-		OddsPriorityBG: false,
-		lastLaunchedVersion: thisVersion,
-		InfiniteScrolling: true,
-		ShowPoints: true,
-		ShowButtons: true,
-		LoadFive: false,
-		HideDlc: false,
-		RepeatIfOnPage: false,
-		RepeatHours: 2,
-		NightTheme: false,
-		LevelPriority: false,
-		PlayAudio: true,
-		DelayBG: 10,
-		MinLevelBG: 0,
-		MinCost: 0,
-		PointsToPreserve: 0,
-		ShowChance: true
-		}, function(data) {
-			settings = data;
-			onPageLoad();
-		}
-	);
-};
-=======
->>>>>>> refs/remotes/ge-ku/master
 
 function onPageLoad(){
 

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -94,7 +94,7 @@ function pagesloaded() {
 				var entCnt = 0;
 				var pointDiff = myPoints - settings.MinPoints;
 				$.each(arr, function(e) {
-					if(totalCost < pointDiff || totalCost == 0){
+					if((totalCost < pointDiff || totalCost == 0) && arr[e].level > settings.MinLevelBG && arr[e].cost > settings.MinCost){
 						totalCost += arr[e].cost;
 						entCnt++;
 					}else{
@@ -102,16 +102,10 @@ function pagesloaded() {
 					}
 				});
 				arr = arr.splice(0, entCnt);
+				console.log(myPoints);
 				
 				var timeouts = [];
 				$.each(arr, function(e) {
-					if (arr[e].level < settings.MinLevelBG) { // this may be unnecessary since level_min search parameter https://www.steamgifts.com/discussion/5WsxS/new-search-parameters
-						return true;
-					}
-					if (arr[e].cost < settings.MinCost){
-						return true;
-					}
-					
 					timeouts.push(setTimeout(function(){
 						console.log(arr[e]), $.post("https://www.steamgifts.com/ajax.php", {
 							xsrf_token: token,

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -97,6 +97,8 @@ function pagesloaded() {
 					if(totalCost < pointDiff || totalCost == 0){
 						totalCost += arr[e].cost;
 						entCnt++;
+					}else{
+						return false;
 					}
 				});
 				arr = arr.splice(0, entCnt);

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -100,7 +100,7 @@ var currPoints=0;
 						totalCost += arr[e].cost;
 						entCnt++;
 						
-						if(entCnt != 1 && totalCost < pointDiff){
+						if(entCnt != 1 && totalCost > pointDiff){
 							entCnt++; 
 							/*This is to go under the preserve limit for the case where
 							the entered giveaway is the last one and we are still above the preserve limit

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -105,7 +105,7 @@ function pagesloaded() {
 							code: arr[e].code
 						}, function(response){
 							var json_response = jQuery.parseJSON(response);
-							if (json_response.points < settings.PointsToPreserve) {
+							if (json_response.points < settings.PointsToPreserve || json_response.msg == "Not Enough Points") {
 								for (var i = 0; i < timeouts.length; i++) {
 									clearTimeout(timeouts[i]);
 								}

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -84,25 +84,34 @@ function pagesloaded() {
 	} else if (settings.OddsPriorityBG) {
 		arr.sort(compareOdds);
 	}
-	var myPoints=0;
+var currPoints=0;
 	link = "https://www.steamgifts.com/";
 	$.get(link, function(data) {
-		myPoints = parseInt($(data).find('a[href="/account"]').find("span.nav__points").text(), 10);
+		currPoints = parseInt($(data).find('a[href="/account"]').find("span.nav__points").text(), 10);
 		}).done(function(){
-			if(myPoints >= settings.MinPoints){
+			if(currPoints >= settings.PointsToPreserve){
 				var totalCost = 0;
 				var entCnt = 0;
-				var pointDiff = myPoints - settings.MinPoints;
+				var pointDiff = currPoints - settings.PointsToPreserve;
 				$.each(arr, function(e) {
-					if((totalCost < pointDiff || totalCost == 0) && arr[e].level > settings.MinLevelBG && arr[e].cost > settings.MinCost){
+					if((totalCost < pointDiff || totalCost == 0) 
+						&& arr[e].level > settings.MinLevelBG 
+						&& arr[e].cost > settings.MinCost){
 						totalCost += arr[e].cost;
 						entCnt++;
+						
+						if(entCnt != 1 && totalCost < pointDiff){
+							entCnt++; 
+							/*This is to go under the preserve limit for the case where
+							the entered giveaway is the last one and we are still above the preserve limit
+							but the last giveaway puts your points under the limit*/
+						}
 					}else{
 						return false;
 					}
 				});
 				arr = arr.splice(0, entCnt);
-				console.log(myPoints);
+				console.log('Current Points: ' + currPoints);
 				
 				var timeouts = [];
 				$.each(arr, function(e) {
@@ -188,7 +197,7 @@ function loadsettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
-		MinPoints: 0,
+		PointsToPreserve: 0,
 		PagesToLoadBG: 3,
 		BackgroundAJ: true,
 		LevelPriorityBG: true,

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -53,7 +53,7 @@ Remember once scanpage is over, pagesloaded is called*/
 function scanpage(e) {
 	var timeLoaded = Math.round(Date.now() / 1000);
     var postsDiv = $(e).find(':not(.pinned-giveaways__inner-wrap) > .giveaway__row-outer-wrap').parent();
-    ((settings.IgnorePinnedBG == true || useWishlistPriorityForMainBG) ? postsDiv : $(e)).find(".giveaway__row-inner-wrap:not(.is-faded) .giveaway__heading__name").each(function() {
+    ((settings.IgnorePinnedBG == true || (useWishlistPriorityForMainBG && pagestemp == pages)) ? postsDiv : $(e)).find(".giveaway__row-inner-wrap:not(.is-faded) .giveaway__heading__name").each(function() {
         var e = $(this).parent().parent().parent(),
             t = this.href.match(/giveaway\/(.+)\//);
         if (t.length > 0) {

--- a/settings.html
+++ b/settings.html
@@ -137,7 +137,7 @@
                         </li>
 						<li>
                             <label>Keep a minimum of
-                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
+                                    <input type="number" size="3" id="PointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>
                     </ul>

--- a/settings.html
+++ b/settings.html
@@ -135,6 +135,11 @@
                                     <input type="number" size="3" id="minCost" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
                                 </label>
                         </li>
+						<li>
+                            <label>Keep a minimum of
+                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (can decrease efficiency depending on autojoin check hours and the minimum number)
+                                </label>
+                        </li>
                     </ul>
                 </ul>
                 <div id="linksContainer">

--- a/settings.html
+++ b/settings.html
@@ -137,7 +137,7 @@
                         </li>
 						<li>
                             <label>Keep a minimum of
-                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (can decrease efficiency depending on autojoin check hours and the minimum number)
+                                    <input type="number" size="3" id="minPoints" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>
                     </ul>

--- a/settings.html
+++ b/settings.html
@@ -136,7 +136,7 @@
                                 </label>
                         </li>
 						<li>
-                            <label>Keep a minimum of
+                            <label>Preserve
                                     <input type="number" size="3" id="pointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>

--- a/settings.html
+++ b/settings.html
@@ -94,6 +94,12 @@
                             <label><input id="chkNoPriorityBG" name="BGpriority" type="radio" checked="checked"/>No priority</label>&nbsp;&nbsp;
                             <label><input id="chkLevelPriorityBG" name="BGpriority" type="radio" />Higher level giveaways</label>&nbsp;&nbsp;
                             <label><input id="chkOddsPriorityBG" name="BGpriority" type="radio" />Higher odds of winning</label>
+							<label><input id="chkWishlistPriorityForMainBG" name="BGpriority" type="checkbox"/>Enter wishlist giveaways first for Main page (All) (will load a minimum of 2 pages)</label>
+                        </li>
+						<li>
+                            <label>
+                                    <input id="chkIgnorePreserveWishlistOnMainBG" type="checkbox"/>Ignore preserve points for wishlist on Main page (All)
+                                </label>
                         </li>
                         <li>
                             <label>

--- a/settings.html
+++ b/settings.html
@@ -137,7 +137,7 @@
                         </li>
 						<li>
                             <label>Keep a minimum of
-                                    <input type="number" size="3" id="PointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
+                                    <input type="number" size="3" id="pointsToPreserve" min="0" max="300" value="0"> points (this is for background autojoin and can decrease efficiency depending on autojoin check hours and the minimum number)
                                 </label>
                         </li>
                     </ul>

--- a/settings.js
+++ b/settings.js
@@ -27,6 +27,7 @@ function loadSettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
+		MinPoints: 0,
 		ShowChance: true
 		}, function(settings) {
 			fillSettingsDiv(settings);
@@ -61,6 +62,7 @@ function fillSettingsDiv(settings){
 	document.getElementById("delayBG").value = settings.DelayBG;
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
+	document.getElementById("minPoints").value = settings.MinPoints;
 	if (settings.RepeatHoursBG == 0) { 
 		document.getElementById("hoursFieldBG").value = "0.5"; 
 	} else { 
@@ -100,6 +102,7 @@ function settingsAttachEventListeners(){
 			DelayBG: parseInt(document.getElementById("delayBG").value, 10),
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
+			MinPoints: parseInt(document.getElementById("minPoints").value, 10),
 			ShowChance: document.getElementById("chkShowChance").checked
 		}, function(){
 			if (location.protocol == "chrome-extension:"){

--- a/settings.js
+++ b/settings.js
@@ -27,7 +27,7 @@ function loadSettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
-		MinPoints: 0,
+		PointsToPreserve: 0,
 		ShowChance: true
 		}, function(settings) {
 			fillSettingsDiv(settings);
@@ -62,7 +62,7 @@ function fillSettingsDiv(settings){
 	document.getElementById("delayBG").value = settings.DelayBG;
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
-	document.getElementById("minPoints").value = settings.MinPoints;
+	document.getElementById("pointsToPreserve").value = settings.PointsToPreserve;
 	if (settings.RepeatHoursBG == 0) { 
 		document.getElementById("hoursFieldBG").value = "0.5"; 
 	} else { 
@@ -102,7 +102,7 @@ function settingsAttachEventListeners(){
 			DelayBG: parseInt(document.getElementById("delayBG").value, 10),
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
-			MinPoints: parseInt(document.getElementById("minPoints").value, 10),
+			PointsToPreserve: parseInt(document.getElementById("pointsToPreserve").value, 10),
 			ShowChance: document.getElementById("chkShowChance").checked
 		}, function(){
 			if (location.protocol == "chrome-extension:"){

--- a/settings.js
+++ b/settings.js
@@ -28,6 +28,8 @@ function loadSettings() {
 		MinLevelBG: 0,
 		MinCost: 0,
 		PointsToPreserve: 0,
+		WishlistPriorityForMainBG: false,
+		IgnorePreserveWishlistOnMainBG: false,
 		ShowChance: true
 		}, function(settings) {
 			fillSettingsDiv(settings);
@@ -63,6 +65,8 @@ function fillSettingsDiv(settings){
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
 	document.getElementById("pointsToPreserve").value = settings.PointsToPreserve;
+	document.getElementById("chkWishlistPriorityForMainBG").checked = settings.WishlistPriorityForMainBG;
+	document.getElementById("chkIgnorePreserveWishlistOnMainBG").checked = settings.IgnorePreserveWishlistOnMainBG;
 	if (settings.RepeatHoursBG == 0) { 
 		document.getElementById("hoursFieldBG").value = "0.5"; 
 	} else { 
@@ -103,6 +107,8 @@ function settingsAttachEventListeners(){
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
 			PointsToPreserve: parseInt(document.getElementById("pointsToPreserve").value, 10),
+			WishlistPriorityForMainBG: document.getElementById("chkWishlistPriorityForMainBG").checked,
+			IgnorePreserveWishlistOnMainBG: document.getElementById("chkIgnorePreserveWishlistOnMainBG").checked,
 			ShowChance: document.getElementById("chkShowChance").checked
 		}, function(){
 			if (location.protocol == "chrome-extension:"){


### PR DESCRIPTION
Another option i thought later on that i think is useful. Not sure how you'll feel about this one since it seems like you want to keep your code simple and i feel like this just makes it more complex and messier so feel free to refuse the request.

If this option is enabled it will load a minimum of 2 pages even if the option is set to 1 and try to enter all of the giveaways that exists on the first page of the wishlist page then continue to check all of the giveaways with the remaining page count.  If ignore preserve points is enabled and the user have less than the set preserve point amount, it will only load 1 page to check the wishlist. All other options are inherited, ignore groups etc. and the prioritize options like higher odds are done for each giveaway list separately (wishlist and all the rest of the giveaways).

My commit information is just terrible so just check the latest state of the files, sorry.