### PR TITLE
Adds name of the won game to the notification.

### DIFF
--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -38,22 +38,25 @@ function calculateWinChance(giveaway, timeLoaded) {
 }
 
 function notify() {
-    chrome.notifications.clear("won_notification", function() {
-        var e = {
-            type: "basic",
-            title: "AutoJoin",
-            message: "You won! Click here to open steamgifts.com",
-            iconUrl: "autologosteam.png"
-        };
-        chrome.notifications.create("won_notification", e, function() {
-			chrome.storage.sync.get({PlayAudio: 'true'}, function (data) {
-				if (data.PlayAudio == true){
-					var e = new Audio("audio.mp3");
-					e.play()
-				}
+	$.get("https://www.steamgifts.com/giveaways/won", function(name) {
+		name = $(name).find(".table__column__heading")[0].innerText;
+		chrome.notifications.clear("won_notification", function() {
+			var e = {
+				type: "basic",
+				title: "AutoJoin",
+				message: "You won " + name + "! Click here to open steamgifts.com",
+				iconUrl: "autologosteam.png"
+			};
+			chrome.notifications.create("won_notification", e, function() {
+				chrome.storage.sync.get({PlayAudio: 'true'}, function (data) {
+					if (data.PlayAudio == true){
+						var e = new Audio("audio.mp3");
+						e.play();
+					}
+				});
 			});
-        })
-    })
+		});
+	});
 }
 
 /*This function scans the pages and calls the function pagesloaded() once it finished


### PR DESCRIPTION
It would be useful to see the name of the won game before clicking the notification to actually go to the won page. I tested this change to the notify() function and this just gets the name of the first game from won games list and add its to the notification message.

I know you said you wanted to "keep number of requests low to avoid temp bans.", but this request happens only when the game is already won which doesn't happen very often, since you only win a few games within a month. I also don't think a request to one html page on the site will get anyone temp banned, and this would be very useful piece of information to add.