### PR TITLE
Separate min cost setting to autojoin button and background autojoin

### DIFF
--- a/autoentry.js
+++ b/autoentry.js
@@ -659,3 +659,19 @@ function checkDLCbyImage(giveaway, encc, frontpage){
 	}
 	xhr.send();
 }
+
+chrome.runtime.onInstalled.addListener(function(updateInfo) {
+	if (updateInfo.previousVersion <= '1.6.2') {
+		console.log('Changing settings of minCost to minCostBG');
+		chrome.storage.sync.get({
+			MinCost: 0
+		}, function(minCost) {
+			chrome.storage.sync.set({
+				MinCost: 0,
+				MinCostBG: minCost			
+			}, function(){
+				console.log('Migrated successfully minCost option from previous version');
+			});
+		});
+	}
+});

--- a/autoentry.js
+++ b/autoentry.js
@@ -37,6 +37,7 @@ $(document).ready(function() {
 			DelayBG: 10,
 			MinLevelBG: 0,
 			MinCost: 0,
+			MinCostBG: 0,
 			ShowChance: true
 		}, function(data) {
 			settings = data;
@@ -232,6 +233,11 @@ function onPageLoad(){
 					if ($(current).find('.giveaway__column--group').length != 0){
 						return;
 					}
+				}
+				var cost = parseInt($(current).find(".giveaway__heading__thin").last().html().match(/\d+/)[0], 10);
+				if (cost < settings.MinCost){
+					console.log ("^Skipped, cost: " + cost + ", your settings.MinCost is " + settings.MinCost);
+					return;
 				}
 
 				var formData = new FormData();

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -125,9 +125,9 @@ function pagesloaded() {
 		if (arr[e].level < settings.MinLevelBG) { // this may be unnecessary since level_min search parameter https://www.steamgifts.com/discussion/5WsxS/new-search-parameters
 			return true;
 		}
-		if (arr[e].cost < settings.MinCost){
+		if (arr[e].cost < settings.MinCostBG){
 			arr[e].showInfo();
-			console.log ("^Skipped, cost: " + arr[e].cost + ", your settings.MinCost is " + settings.MinCost);
+			console.log ("^Skipped, cost: " + arr[e].cost + ", your settings.MinCostBG is " + settings.MinCostBG);
 			return true;
 		}
 		if (arr[e].timeleft > settings.MaxTimeLeftBG && settings.MaxTimeLeftBG != 0) {

--- a/settings.html
+++ b/settings.html
@@ -85,6 +85,11 @@
                                 <input id="chkIgnorePinned" type="checkbox">Ignore featured giveaways for AutoJoin
                             </label>
                         </li>
+                        <li class="dependsOnAutoJoinButton">
+                            <label>Minimum giveaway cost in points to enter: 
+                                <input type="number" size="3" id="minCost" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
+                            </label>
+                        </li>
                     </ul>
                     <br />
                     <li class="titleListItem">AutoJoin in background (even when steamgifts.com in not opened)</li>
@@ -156,7 +161,7 @@
                         </li>
                         <li class="dependsOnBackgroundAutoJoin">
                             <label>Minimum giveaway cost in points to enter: 
-                                <input type="number" size="3" id="minCost" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
+                                <input type="number" size="3" id="minCostBG" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
                             </label>
                         </li>
 						<li class="dependsOnBackgroundAutoJoin">

--- a/settings.js
+++ b/settings.js
@@ -30,6 +30,7 @@ function loadSettings() {
 		DelayBG: 10,
 		MinLevelBG: 0,
 		MinCost: 0,
+		MinCostBG: 0,
 		PointsToPreserve: 0,
 		WishlistPriorityForMainBG: false,
 		IgnorePreserveWishlistOnMainBG: false,
@@ -70,6 +71,7 @@ function fillSettingsDiv(settings){
 	document.getElementById("delayBG").value = settings.DelayBG;
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
+	document.getElementById("minCostBG").value = settings.MinCostBG;
 	document.getElementById("pointsToPreserve").value = settings.PointsToPreserve;
 	document.getElementById("chkWishlistPriorityForMainBG").checked = settings.WishlistPriorityForMainBG;
 	document.getElementById("chkIgnorePreserveWishlistOnMainBG").checked = settings.IgnorePreserveWishlistOnMainBG;
@@ -115,6 +117,7 @@ function settingsAttachEventListeners(){
 			DelayBG: parseInt(document.getElementById("delayBG").value, 10),
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
+			MinCostBG: parseInt(document.getElementById("minCostBG").value, 10),
 			PointsToPreserve: parseInt(document.getElementById("pointsToPreserve").value, 10),
 			WishlistPriorityForMainBG: document.getElementById("chkWishlistPriorityForMainBG").checked,
 			IgnorePreserveWishlistOnMainBG: document.getElementById("chkIgnorePreserveWishlistOnMainBG").checked,


### PR DESCRIPTION
I mainly use autojoin button and always was curious about option to autojoin giveaways only above certain cost, same option  as bg autojoin has. Let me know what you think about it