### PR TITLE
Add setting to configure delay on autojoin, joining speed fix

### DIFF
--- a/autoentry.js
+++ b/autoentry.js
@@ -35,6 +35,7 @@ $(document).ready(function() {
 			PlayAudio: true,
 			AudioVolume: 1,
 			DelayBG: 10,
+			Delay: 10,
 			MinLevelBG: 0,
 			MinCost: 0,
 			MinCostBG: 0,
@@ -225,21 +226,20 @@ function onPageLoad(){
 			selectItems = "#posts " + selectItems;
 		}
 
-		$(selectItems).each(function(iteration){
-			timeouts.push(setTimeout($.proxy(function(){
-				var current = $(this).parent().parent().parent();
-				
-				if (settings.IgnoreGroups){
-					if ($(current).find('.giveaway__column--group').length != 0){
-						return;
-					}
-				}
-				var cost = parseInt($(current).find(".giveaway__heading__thin").last().html().match(/\d+/)[0], 10);
-				if (cost < settings.MinCost){
-					console.log ("^Skipped, cost: " + cost + ", your settings.MinCost is " + settings.MinCost);
+		$(selectItems).each(function(iteration) {
+			var current = $(this).parent().parent().parent();
+
+			if (settings.IgnoreGroups) {
+				if ($(current).find('.giveaway__column--group').length != 0) {
 					return;
 				}
-
+			}
+			var cost = parseInt($(current).find(".giveaway__heading__thin").last().html().match(/\d+/)[0], 10);
+			if (cost < settings.MinCost) {
+				console.log("^Skipped, cost: " + cost + ", your settings.MinCost is " + settings.MinCost);
+				return;
+			}
+			timeouts.push(setTimeout($.proxy(function () {
 				var formData = new FormData();
 				formData.append('xsrf_token', token);
 				formData.append('do', 'entry_insert');
@@ -269,7 +269,7 @@ function onPageLoad(){
 						}
 					});
 
-			}, this), iteration * 3000));
+			}, this), timeouts.length * settings.Delay * 1000 + Math.floor(Math.random()*1000)));
 		});
 		$('#btnAutoJoin').val('Good luck!');
 	}

--- a/backgroundpage.js
+++ b/backgroundpage.js
@@ -261,6 +261,7 @@ function loadsettings() {
 		PageForBG: 'wishlist',
 		RepeatHoursBG: 5,
 		DelayBG: 10,
+		Delay: 10,
 		MaxTimeLeftBG: 0, //in seconds
 		MinLevelBG: 0,
 		MinCost: 0,
@@ -370,6 +371,14 @@ chrome.runtime.onInstalled.addListener(function(updateInfo) {
 			}, function(){
 				console.log('Migrated successfully minCost option from previous version');
 			});
+		});
+	}
+	if (updateInfo.previousVersion <= '1.6.3') {
+		console.log('Setting delay default value');
+		chrome.storage.sync.set({
+			Delay: 10	
+		}, function(){
+			console.log('Delay default values was set successfully');
 		});
 	}
 });

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
    "short_name": "AutoJoin",
    "description": "Automatically enters giveaways from Steamgifts.com and site enhancements",
    "permissions": [ "alarms", "notifications", "storage", "tabs", "*://www.steamgifts.com/*", "*://store.steampowered.com/*" ],
-   "version": "1.6.3.1",
+   "version": "1.6.3.2",
    "web_accessible_resources": [
        "settings.html",
        "night.css",

--- a/settings.html
+++ b/settings.html
@@ -90,6 +90,11 @@
                                 <input type="number" size="3" id="minCost" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
                             </label>
                         </li>
+                        <li class="dependsOnAutoJoinButton">
+                            <label>Delay between requests: 
+                                <input type="number" size="2" id="delay" min="5" max="60" value="10"> seconds
+                            </label>
+                        </li>
                     </ul>
                     <br />
                     <li class="titleListItem">AutoJoin in background (even when steamgifts.com in not opened)</li>

--- a/settings.js
+++ b/settings.js
@@ -69,6 +69,7 @@ function fillSettingsDiv(settings){
 	document.getElementById("pagestoloadBG").value = settings.PagesToLoadBG;
 	document.getElementById("pageforBG").value = settings.PageForBG;
 	document.getElementById("delayBG").value = settings.DelayBG;
+	document.getElementById("delay").value = settings.Delay;
 	document.getElementById("minLevelBG").value = settings.MinLevelBG;
 	document.getElementById("minCost").value = settings.MinCost;
 	document.getElementById("minCostBG").value = settings.MinCostBG;
@@ -115,6 +116,7 @@ function settingsAttachEventListeners(){
 			PagesToLoadBG: parseInt(document.getElementById("pagestoloadBG").value, 10),
 			PageForBG: document.getElementById("pageforBG").value,
 			DelayBG: parseInt(document.getElementById("delayBG").value, 10),
+			Delay: parseInt(document.getElementById("delay").value, 10),
 			MinLevelBG: parseInt(document.getElementById("minLevelBG").value, 10),
 			MinCost: parseInt(document.getElementById("minCost").value, 10),
 			MinCostBG: parseInt(document.getElementById("minCostBG").value, 10),


### PR DESCRIPTION
I had problem after MinCost being introduced that i could wait like half minute before entering first giveaway. This PR fixes it and introduce new setting, delay configuration variable for autojoin with some random offset