### PR TITLE
Feature: add maximum giveaway cost filter

### DIFF
--- a/html/settings.html
+++ b/html/settings.html
@@ -127,6 +127,11 @@
                             </label>
                         </li>
                         <li class="dependsOnAutoJoinButton">
+                            <label>Maximum giveaway cost in points to enter: 
+                                <input type="number" size="3" id="maxCost" min="-1" max="200" value="-1"> (set it to -1 to enter all giveaways)
+                            </label>
+                        </li>
+                        <li class="dependsOnAutoJoinButton">
                             <label>Delay between requests: 
                                 <input type="number" size="2" id="delay" min="5" max="60" value="10"> seconds
                             </label>
@@ -214,6 +219,11 @@
                         <li class="dependsOnBackgroundAutoJoin">
                             <label>Minimum giveaway cost in points to enter: 
                                 <input type="number" size="3" id="minCostBG" min="0" max="200" value="0"> (set it to 0 to enter all giveaways)
+                            </label>
+                        </li>
+                        <li class="dependsOnBackgroundAutoJoin">
+                            <label>Maximum giveaway cost in points to enter: 
+                                <input type="number" size="3" id="maxCostBG" min="-1" max="200" value="-1"> (set it to -1 to enter all giveaways)
                             </label>
                         </li>
 						<li class="dependsOnBackgroundAutoJoin">

--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -347,6 +347,8 @@ chrome.storage.sync.get(
         MinLevelBG: 0,
         MinCost: 0,
         MinCostBG: 0,
+        MaxCost: -1,
+        MaxCostBG: -1,
         ShowChance: true,
         PreciseTime: false,
       },
@@ -674,7 +676,7 @@ function onPageLoad() {
               .match(/\d+/)[0],
             10
           );
-          if (cost >= settings.MinCost) {
+          if ((cost >= settings.MinCost) && ((settings.MaxCost == -1) || (cost <= settings.MaxCost))) {
             timeouts.push(
               setTimeout(
                 $.proxy(function() {
@@ -722,9 +724,15 @@ function onPageLoad() {
               )
             );
           } else {
-            console.log(
-              `^Skipped, cost: ${cost}, your settings.MinCost is ${settings.MinCost}`
-            );
+            if (cost < settings.MinCost) {
+              console.log(
+                `^Skipped, cost: ${cost}, your settings.MinCost is ${settings.MinCost}`
+              );
+            } else {
+              console.log(
+                `^Skipped, cost: ${cost}, your settings.MaxCost is ${settings.MaxCost}`
+              );
+            }
           }
         }
       });

--- a/js/backgroundpage.js
+++ b/js/backgroundpage.js
@@ -504,6 +504,13 @@ function pagesloaded() {
       );
       return true;
     }
+    if ((settings.MaxCostBG != -1) && (arr[e].cost > settings.MaxCostBG)) {
+      arr[e].showInfo();
+      console.log(
+        `^Skipped, cost: ${arr[e].cost}, your settings.MaxCostBG is ${settings.MaxCostBG}`
+      );
+      return true;
+    }
     if (
       arr[e].timeleft > settings.MaxTimeLeftBG &&
       settings.MaxTimeLeftBG !== 0
@@ -717,6 +724,7 @@ function loadsettings() {
       MaxTimeLeftBG: 0, // in seconds
       MinLevelBG: 0,
       MinCostBG: 0,
+      MaxCostBG: -1,
       PointsToPreserve: 0,
       WishlistPriorityForMainBG: false,
       IgnorePreserveWishlistOnMainBG: false,

--- a/js/settings.js
+++ b/js/settings.js
@@ -41,6 +41,8 @@ function loadSettings() {
       MinLevelBG: 0,
       MinCost: 0,
       MinCostBG: 0,
+      MaxCost: -1,
+      MaxCostBG: -1,
       PointsToPreserve: 0,
       WishlistPriorityForMainBG: false,
       IgnorePreserveWishlistOnMainBG: false,
@@ -109,6 +111,8 @@ function fillSettingsDiv(settings) {
   document.getElementById('minLevelBG').value = settings.MinLevelBG;
   document.getElementById('minCost').value = settings.MinCost;
   document.getElementById('minCostBG').value = settings.MinCostBG;
+  document.getElementById('maxCost').value = settings.MaxCost;
+  document.getElementById('maxCostBG').value = settings.MaxCostBG;
   document.getElementById('pointsToPreserve').value = settings.PointsToPreserve;
   document.getElementById('chkWishlistPriorityForMainBG').checked =
     settings.WishlistPriorityForMainBG;
@@ -184,6 +188,8 @@ function settingsAttachEventListeners() {
         MinLevelBG: parseInt(document.getElementById('minLevelBG').value, 10),
         MinCost: parseInt(document.getElementById('minCost').value, 10),
         MinCostBG: parseInt(document.getElementById('minCostBG').value, 10),
+        MaxCost: parseInt(document.getElementById('maxCost').value, 10),
+        MaxCostBG: parseInt(document.getElementById('maxCostBG').value, 10),
         PointsToPreserve: parseInt(
           document.getElementById('pointsToPreserve').value,
           10


### PR DESCRIPTION
Adds the option to limit the giveaways to enter by limiting the maximum giveaway cost (in addition to the already existing limit for a minimum cost).

By default (and when set to `-1`), this option does not limit the maximum cost.