### PR TITLE
Better startup time

### DIFF
--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -300,63 +300,71 @@ function modifyPageDOM(pageDOM, timeLoaded) {
   });
 }
 
-chrome.storage.sync.get(
-  {
-    lastLaunchedVersion: thisVersion,
-  },
-  () => {
-    chrome.storage.sync.get(
-      {
-        AutoJoinButton: false,
-        AutoDescription: true,
-        IgnoreGroups: false,
-        IgnorePinned: true,
-        IgnoreWhitelist: false,
-        IgnoreGroupsBG: false,
-        IgnorePinnedBG: true,
-        PageForBG: 'wishlist',
-        RepeatHoursBG: 5,
-        PagesToLoad: 3,
-        PagesToLoadBG: 2,
-        BackgroundAJ: false,
-        LevelPriorityBG: true,
-        OddsPriorityBG: false,
-        lastLaunchedVersion: thisVersion,
-        InfiniteScrolling: true,
-        ShowPoints: true,
-        ShowButtons: true,
-        LoadFive: false,
-        HideDlc: false,
-        HideEntered: false,
-        HideGroups: false,
-        HideNonTradingCards: false,
-        HideWhitelist: false,
-        HideLevelsBelow: 0,
-        PriorityGroup: false,
-        PriorityRegion: false,
-        PriorityWhitelist: false,
-        PriorityWishlist: true,
-        RepeatIfOnPage: false,
-        RepeatHours: 5,
-        NightTheme: false,
-        LevelPriority: false,
-        PlayAudio: true,
-        AudioVolume: 1,
-        DelayBG: 10,
-        Delay: 10,
-        MinLevelBG: 0,
-        MinCost: 0,
-        MinCostBG: 0,
-        ShowChance: true,
-        PreciseTime: false,
-      },
-      data => {
-        settings = data;
-        loadCache();
-      }
-    );
-  }
-);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', getSettings);
+} else {
+  getSettings();
+}
+
+function getSettings() {
+  chrome.storage.sync.get(
+    {
+      lastLaunchedVersion: thisVersion,
+    },
+    () => {
+      chrome.storage.sync.get(
+        {
+          AutoJoinButton: false,
+          AutoDescription: true,
+          IgnoreGroups: false,
+          IgnorePinned: true,
+          IgnoreWhitelist: false,
+          IgnoreGroupsBG: false,
+          IgnorePinnedBG: true,
+          PageForBG: 'wishlist',
+          RepeatHoursBG: 5,
+          PagesToLoad: 3,
+          PagesToLoadBG: 2,
+          BackgroundAJ: false,
+          LevelPriorityBG: true,
+          OddsPriorityBG: false,
+          lastLaunchedVersion: thisVersion,
+          InfiniteScrolling: true,
+          ShowPoints: true,
+          ShowButtons: true,
+          LoadFive: false,
+          HideDlc: false,
+          HideEntered: false,
+          HideGroups: false,
+          HideNonTradingCards: false,
+          HideWhitelist: false,
+          HideLevelsBelow: 0,
+          PriorityGroup: false,
+          PriorityRegion: false,
+          PriorityWhitelist: false,
+          PriorityWishlist: true,
+          RepeatIfOnPage: false,
+          RepeatHours: 5,
+          NightTheme: false,
+          LevelPriority: false,
+          PlayAudio: true,
+          AudioVolume: 1,
+          DelayBG: 10,
+          Delay: 10,
+          MinLevelBG: 0,
+          MinCost: 0,
+          MinCostBG: 0,
+          ShowChance: true,
+          PreciseTime: false,
+        },
+        data => {
+          settings = data;
+          loadCache();
+        }
+      );
+    }
+  );
+}
 
 function loadCache() {
   chrome.storage.local.get(data => {

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
       "scripts": [ "js/jquery.min.js", "js/backgroundpage.js" ]
    },
    "content_scripts": [ {
+      "run_at": "document_start",
       "css": [ "css/general.css" ],
       "js": [ "js/jquery.min.js", "js/autoentry.js", "js/misc.js", "js/settings.js" ],
       "matches": [ "*://www.steamgifts.com/", "*://www.steamgifts.com/giveaways/search?*", "*://steamgifts.com/", "*://steamgifts.com/giveaways/search?*" ]


### PR DESCRIPTION
Avoid flickering by using [run_at](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#run_at), and delay the js startup until the DOM is loaded but before all unneeded resources from the page are loaded.