### PR TITLE
Add a config to hide giveaways below a certain cost

### DIFF
--- a/html/settings.html
+++ b/html/settings.html
@@ -125,6 +125,9 @@
                             </label> &nbsp;&nbsp;
                             <label> 
                                 Hide giveaways below level <input id="hideLevelsBelow" type="number" min="0" max="10" value="0"/>
+                            </label> &nbsp;&nbsp;
+                            <label> 
+                                Hide giveaways with cost below <input id="hideCostsBelow" type="number" min="0" max="50" value="0"/>
                             </label>
                         </li>
                         <li class="dependsOnAutoJoinButton">

--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -200,6 +200,22 @@ function modifyPageDOM(pageDOM, timeLoaded) {
     }
     if (level < settings.HideLevelsBelow) giveaway.remove();
 
+    const copiesAndCostElements = giveaway.querySelectorAll(
+      '.giveaway__heading__thin'
+    );
+    let costElement;
+    if (copiesAndCostElements.length > 1) {
+      costElement = copiesAndCostElements[1];
+    } else {
+      costElement = copiesAndCostElements[0];
+    }
+    const cost = Number.parseInt(
+      costElement.textContent.match(/\d+/)[0],
+      10
+    );
+    console.log(cost, " ", settings.HideCostsBelow)
+    if (cost < settings.HideCostsBelow) giveaway.remove();
+
     if (giveawayInnerWrap.classList.contains('is-faded')) {
       if (settings.HideEntered) {
         giveaway.remove();
@@ -341,6 +357,7 @@ function getSettings() {
           HideNonTradingCards: false,
           HideWhitelist: false,
           HideLevelsBelow: 0,
+          HideCostsBelow: 0,
           PriorityGroup: false,
           PriorityRegion: false,
           PriorityWhitelist: false,

--- a/js/settings.js
+++ b/js/settings.js
@@ -28,6 +28,7 @@ function loadSettings() {
       HideNonTradingCards: false,
       HideWhitelist: false,
       HideLevelsBelow: 0,
+      HideCostsBelow: 0,
       PriorityGroup: false,
       PriorityRegion: false,
       PriorityWhitelist: false,
@@ -79,6 +80,7 @@ function fillSettingsDiv(settings) {
     settings.HideNonTradingCards;
   document.getElementById('chkHideWhitelist').checked = settings.HideWhitelist;
   document.getElementById('hideLevelsBelow').value = settings.HideLevelsBelow;
+  document.getElementById('hideCostsBelow').value = settings.HideCostsBelow;
   document.getElementById('chkNightTheme').checked = settings.NightTheme;
   // document.getElementById("chkLevelPriority").checked = settings.LevelPriority;
   document.getElementById('chkRepeatIfOnPage').checked =
@@ -157,6 +159,10 @@ function settingsAttachEventListeners() {
         HideWhitelist: document.getElementById('chkHideWhitelist').checked,
         HideLevelsBelow: parseInt(
           document.getElementById('hideLevelsBelow').value,
+          10
+        ),
+        HideCostsBelow: parseInt(
+          document.getElementById('hideCostsBelow').value,
           10
         ),
         RepeatIfOnPage: document.getElementById('chkRepeatIfOnPage').checked,


### PR DESCRIPTION
While I don't use this extension to auto-join giveaways, I use it extensively to browse and join giveaways manually. An option that might be handy for people like me is to hide giveaways below a certain cost. This PR aims to add that config.

Hopefully with this, users can see a less cluttered list and get to the juicy giveaways easier 😁 