### PR TITLE
more giveaways filter, pinned footer fixes

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -337,7 +337,7 @@ nav {
 	text-align: center;
 	border-radius: 1em 1em 0 0;
 	color: white;
-	background-color: #95a4c0;
+	background-color: #2f3540;
 }
 #ajFooter #ajFooterArrow {
 	transition: transform .4s;
@@ -346,12 +346,12 @@ nav {
 #ajFooter.pinned #ajFooterArrow {
 	transform: rotate(180deg);
 }
-#ajFooter.pinned .footer__outer-wrap {
+#ajFooter.pinned footer {
 	max-height: 100%;
 	padding: 15px 25px;
 }
-#ajFooter .footer__outer-wrap {
-	background-color: #95a4c0;
+#ajFooter footer {
+	background-color: #2f3540;
 	transition: all 0.2s ease-in;
 	max-height: 0px;
 	padding: 0 25px;

--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -2,7 +2,7 @@ let giveaways = [];
 let settingsInjected = false;
 let settings;
 let token;
-const thisVersion = 20220612;
+const thisVersion = 20230517;
 const currentState = {
   amountOfPoints: 0,
   set points(n) {
@@ -260,6 +260,13 @@ function modifyPageDOM(pageDOM, timeLoaded) {
       }
       giveawayInnerWrap.appendChild(joinBtn);
     }
+    
+    //Replaces the More Giveaways '/game/*' url with 'search?q=', retaining extension features
+    //.substring(0,35) because steamgifts adds extra characters (...) to the headings
+    const giveawayNameURI = encodeURIComponent(giveaway.querySelector('.giveaway__heading__name').textContent.substring(0,35));
+    const MoreGiveawaysBtn = giveaway.querySelector('.giveaway__icon[href^="/game/"]');
+    if(MoreGiveawaysBtn) MoreGiveawaysBtn.href = `/giveaways/search?q=`+giveawayNameURI;
+
     const giveawayHideEl = giveaway.querySelector('.giveaway__hide');
     if (giveawayHideEl) giveawayHideEl.dataset.popup = '';
     if (

--- a/js/misc.js
+++ b/js/misc.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ajFooterArrowWrap.appendChild(ajFooterArrow);
   ajFooter.appendChild(ajFooterArrowWrap);
 
-  const sgFooter = document.querySelector('.footer__outer-wrap');
+  const sgFooter = document.querySelector('footer');
   sgFooter.parentElement.insertBefore(ajFooter, sgFooter);
   ajFooter.appendChild(sgFooter);
 

--- a/manifest.json
+++ b/manifest.json
@@ -80,7 +80,7 @@
     "*://store.steampowered.com/*"
   ],
   "optional_permissions": ["*://steamcommunity.com/profiles/*"],
-  "version": "1.9.3",
+  "version": "1.9.4",
   "web_accessible_resources": [
     "html/settings.html",
     "css/night.css",


### PR DESCRIPTION
-steamgifts changed their 'More Giveaways' filter page, thus replacing the url with a normal search query allows the extension features to be retained.

-Updated the references and background to the footer so that pinning works again.

----------------
Note:
This request is in regards to https://github.com/ge-ku/AutoJoin-for-SteamGifts/issues/61
I was really missing the filter page so I thought replacing the url was the most unobtrusive way of solving it. The url is not replaced on individual giveaway pages, so the /game/* page can still be reached.