### PR TITLE
Fix for Dynamic Signature

### DIFF
--- a/css/night.css
+++ b/css/night.css
@@ -9,7 +9,8 @@ div.page__outer-wrap .giveaway_image_avatar,
 .table_image_thumbnail,
 .table_image_avatar,
 .comment__summary img,
-.markdown img
+.markdown img,
+.widget-container img
 {
     filter: invert(100%);
 }


### PR DESCRIPTION
If "Night theme" is enabled and you go to any of the giveaways you created and then select "Dynamic Signature," you will notice the image is inverted. This PR addresses the issue.