### PR TITLE
Added option to hide giveaways above a certain level and point cost

### DIFF
--- a/html/settings.html
+++ b/html/settings.html
@@ -129,6 +129,9 @@
                             <label> 
                                 Hide giveaways with cost below <input id="hideCostsBelow" type="number" min="0" max="50" value="0"/>
                             </label>
+                            <label>
+                                Hide giveaways above level <input id="hideLevelsAbove" type="number" min="0" max="10" value="10"/>
+                            </label> &nbsp;&nbsp;
                         </li>
                         <li class="dependsOnAutoJoinButton">
                             <label>Minimum giveaway cost in points to enter: 

--- a/html/settings.html
+++ b/html/settings.html
@@ -132,6 +132,9 @@
                             <label>
                                 Hide giveaways above level <input id="hideLevelsAbove" type="number" min="0" max="10" value="10"/>
                             </label> &nbsp;&nbsp;
+                            <label> 
+                                Hide giveaways with cost above <input id="hideCostsAbove" type="number" min="0" max="50" value="50"/>
+                            </label>
                         </li>
                         <li class="dependsOnAutoJoinButton">
                             <label>Minimum giveaway cost in points to enter: 

--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -214,6 +214,19 @@ function modifyPageDOM(pageDOM, timeLoaded) {
       const cost = Number.parseInt(costElement.textContent.match(/\d+/)[0], 10);
       if (cost < settings.HideCostsBelow) giveaway.remove();
     }
+    if (settings.HideCostsAbove < 50) {
+      const copiesAndCostElements = giveaway.querySelectorAll(
+        '.giveaway__heading__thin'
+      );
+      let costElement;
+      if (copiesAndCostElements.length > 1) {
+        costElement = copiesAndCostElements[1];
+      } else {
+        costElement = copiesAndCostElements[0];
+      }
+      const cost = Number.parseInt(costElement.textContent.match(/\d+/)[0], 10);
+      if (cost > settings.HideCostsAbove) giveaway.remove();
+    }
 
     if (giveawayInnerWrap.classList.contains('is-faded')) {
       if (settings.HideEntered) {
@@ -359,6 +372,7 @@ function getSettings() {
           HideLevelsBelow: 0,
           HideCostsBelow: 0,
           HideLevelsAbove: 10,
+          HideCostsAbove: 50,
           PriorityGroup: false,
           PriorityRegion: false,
           PriorityWhitelist: false,

--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -199,6 +199,7 @@ function modifyPageDOM(pageDOM, timeLoaded) {
       level = parseInt(levelEl.textContent.match(/\d+/)[0], 10);
     }
     if (level < settings.HideLevelsBelow) giveaway.remove();
+    if (level > settings.HideLevelsAbove) giveaway.remove();
 
     if (settings.HideCostsBelow > 0) {
       const copiesAndCostElements = giveaway.querySelectorAll(
@@ -357,6 +358,7 @@ function getSettings() {
           HideWhitelist: false,
           HideLevelsBelow: 0,
           HideCostsBelow: 0,
+          HideLevelsAbove: 10,
           PriorityGroup: false,
           PriorityRegion: false,
           PriorityWhitelist: false,

--- a/js/settings.js
+++ b/js/settings.js
@@ -30,6 +30,7 @@ function loadSettings() {
       HideLevelsBelow: 0,
       HideCostsBelow: 0,
       HideLevelsAbove: 10,
+      HideCostsAbove: 50,
       PriorityGroup: false,
       PriorityRegion: false,
       PriorityWhitelist: false,
@@ -83,6 +84,7 @@ function fillSettingsDiv(settings) {
   document.getElementById('hideLevelsBelow').value = settings.HideLevelsBelow;
   document.getElementById('hideCostsBelow').value = settings.HideCostsBelow;
   document.getElementById('hideLevelsAbove').value = settings.HideLevelsAbove;
+  document.getElementById('hideCostsAbove').value = settings.HideCostsAbove;
   document.getElementById('chkNightTheme').checked = settings.NightTheme;
   // document.getElementById("chkLevelPriority").checked = settings.LevelPriority;
   document.getElementById('chkRepeatIfOnPage').checked =
@@ -169,6 +171,10 @@ function settingsAttachEventListeners() {
         ),
         HideLevelsAbove: parseInt(
           document.getElementById('hideLevelsAbove').value,
+          10
+        ),
+        HideCostsAbove: parseInt(
+          document.getElementById('hideCostsAbove').value,
           10
         ),
         RepeatIfOnPage: document.getElementById('chkRepeatIfOnPage').checked,

--- a/js/settings.js
+++ b/js/settings.js
@@ -29,6 +29,7 @@ function loadSettings() {
       HideWhitelist: false,
       HideLevelsBelow: 0,
       HideCostsBelow: 0,
+      HideLevelsAbove: 10,
       PriorityGroup: false,
       PriorityRegion: false,
       PriorityWhitelist: false,
@@ -81,6 +82,7 @@ function fillSettingsDiv(settings) {
   document.getElementById('chkHideWhitelist').checked = settings.HideWhitelist;
   document.getElementById('hideLevelsBelow').value = settings.HideLevelsBelow;
   document.getElementById('hideCostsBelow').value = settings.HideCostsBelow;
+  document.getElementById('hideLevelsAbove').value = settings.HideLevelsAbove;
   document.getElementById('chkNightTheme').checked = settings.NightTheme;
   // document.getElementById("chkLevelPriority").checked = settings.LevelPriority;
   document.getElementById('chkRepeatIfOnPage').checked =
@@ -163,6 +165,10 @@ function settingsAttachEventListeners() {
         ),
         HideCostsBelow: parseInt(
           document.getElementById('hideCostsBelow').value,
+          10
+        ),
+        HideLevelsAbove: parseInt(
+          document.getElementById('hideLevelsAbove').value,
           10
         ),
         RepeatIfOnPage: document.getElementById('chkRepeatIfOnPage').checked,


### PR DESCRIPTION
After using AutoJoin for SteamGifts for quite some time now, I have always wanted an option to hide giveaways above a certain level and point cost, in addition to the option to hide below a certain level and point cost. This is useful when trying to join as many giveaways as possible without caring for the value of the game, for example.

I implemented this option similar to how the option to hide below a certain level and point cost was implemented. The visual representation follows your design for the options (see screenshot). For the default values, I chose 10 for the level and 50 for the point threshold, which filters out nothing, the same as having the filter for hiding giveaways below a certain level and point cost set to 0.

![image](https://github.com/ge-ku/AutoJoin-for-SteamGifts/assets/59022685/2dc12df9-3405-4716-be21-858f2faa0e26)

I have tested the implementation, and everything seems to work as intended.