### PR TITLE
Add option to post random comment separated with #

### DIFF
--- a/html/settings.html
+++ b/html/settings.html
@@ -36,7 +36,7 @@
                         </li>
                         <li>
                             <label> 
-                                <input id="chkAutoComment" type="checkbox"/>Automatically post following comment on joined giveaways: <input id="txtAutoComment" type="text"/>
+                                <input id="chkAutoComment" type="checkbox"/>Automatically post following comment on joined giveaways: <input id="txtAutoComment" type="text" placeholder="Seperat different comments to choose from with #"/>
                             </label>
                         </li>
                         <li>

--- a/js/autoentry.js
+++ b/js/autoentry.js
@@ -937,20 +937,25 @@ function onPageLoad() {
             updateButtons();
             /* Post Comment */
             if (settings.AutoComment && settings.Comment) {
-              const formData = new FormData();
-              formData.append('xsrf_token', token);
-              formData.append('do', 'comment_new');
-              formData.append('description', settings.Comment);
-              formData.append('parent_id', '');
-              fetch(`${window.location.origin}${giveawayUrlPath}`, {
-                method: 'post',
-                credentials: 'include',
-                body: formData,
-              })
-                .then((resp) => resp.json())
-                .then((jsonResponse) => {
-                  console.debug('Comment response', jsonResponse);
-                });
+              /* parse comment settings */
+              let comments = settings.Comment.split('#').map(comment => comment.trim());
+              let chosenComment = comments[Math.floor(Math.random() * comments.length)];
+              if (chosenComment) { // checks if an empty comment has been selected
+                const formData = new FormData();
+                formData.append('xsrf_token', token);
+                formData.append('do', 'comment_new');
+                formData.append('description', chosenComment);
+                formData.append('parent_id', '');
+                fetch(`${window.location.origin}${giveawayUrlPath}`, {
+                  method: 'post',
+                  credentials: 'include',
+                  body: formData,
+                })
+                  .then((resp) => resp.json())
+                  .then((jsonResponse) => {
+                    console.debug('Comment response', jsonResponse);
+                  });
+              }
             }
           } else {
             thisWrap.toggleClass('is-faded');


### PR DESCRIPTION
This request is in regards to #65.

Implemented feature request for an option to post a random comment.
I changed the separating symbol from ";" to "#" as this allows the usage of comments including smiles like ";)".

Placeholder:
![image](https://github.com/ge-ku/AutoJoin-for-SteamGifts/assets/59022685/50813525-8ab6-468c-b7f5-9ca91070a39e)

As described in the issue, I added the option to input empty comments which results in no comments being posted.
